### PR TITLE
Feature/seed collections

### DIFF
--- a/samples/ApiSample/test/Seeders/UserTaskCollection.cs
+++ b/samples/ApiSample/test/Seeders/UserTaskCollection.cs
@@ -1,0 +1,13 @@
+﻿using Janus.Seeding;
+
+namespace Janus.SampleApi
+{
+    public class UserTaskCollection : SeederCollection
+    {
+        public UserTaskCollection()
+        {
+            this.AddSeeder<UserEntitySeeder>();
+            this.AddSeeder<TaskEntitySeeder>();
+        }
+    }
+}

--- a/samples/ApiSample/test/Tests/SeedCollectionTests.cs
+++ b/samples/ApiSample/test/Tests/SeedCollectionTests.cs
@@ -1,7 +1,6 @@
 using Bogus;
 using Janus.SampleApi.Data;
 using Janus.Seeding;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System.Linq;
@@ -12,7 +11,7 @@ using System.Threading.Tasks;
 namespace Janus.SampleApi
 {
     [TestClass]
-    public class DataSeederTests
+    public class SeedCollectionTests
     {
         private ApiIntegrationTestFactory<Startup> testFactory;
 
@@ -38,8 +37,7 @@ namespace Janus.SampleApi
         {
             // Arrange
             this.testFactory.WithDataContext<AppDbContext>("Default")
-                .WithSeedData<UserEntitySeeder>()
-                .WithSeedData<TaskEntitySeeder>();
+                .WithSeedCollection<UserTaskCollection>();
 
             var client = testFactory.CreateClient();
             IEntitySeeder userSeeder = testFactory.GetDataContextSeedData<AppDbContext, UserEntitySeeder>();

--- a/src/Janus.Core/ApiIntegrationTestFactory`1.cs
+++ b/src/Janus.Core/ApiIntegrationTestFactory`1.cs
@@ -21,7 +21,7 @@ namespace Janus
 
         private string solutionRelativeContentRoot = ".";
         private readonly string connectionStringDatabaseKey;
-        private List<TestDatabaseConfiguration> databaseConfigurations = new List<TestDatabaseConfiguration>();
+        private readonly List<TestDatabaseConfiguration> databaseConfigurations = new List<TestDatabaseConfiguration>();
 
         public ApiIntegrationTestFactory() : this(DefaultDatabaseKey)
         { }
@@ -71,12 +71,13 @@ namespace Janus
                 throw new ArgumentNullException(nameof(configurationConnectionStringKey), "You must provide the fully qualified IConfiguration Key used to discover the connection string value in the configuration system.");
             }
 
-            var dbConfig = new TestDatabaseConfiguration<TContext>(configurationConnectionStringKey, executingTest);
-
-            // If this specific DBContext can't use the Factory database key, then we use the DBContext specific key.
-            dbConfig.ConnectionStringDatabaseKey = string.IsNullOrEmpty(connectionStringDatabaseKey)
-                ? this.connectionStringDatabaseKey
-                : connectionStringDatabaseKey;
+            var dbConfig = new TestDatabaseConfiguration<TContext>(configurationConnectionStringKey, executingTest)
+            {
+                // If this specific DBContext can't use the Factory database key, then we use the DBContext specific key.
+                ConnectionStringDatabaseKey = string.IsNullOrEmpty(connectionStringDatabaseKey)
+                    ? this.connectionStringDatabaseKey
+                    : connectionStringDatabaseKey
+            };
 
             var seedBuilder = new DbContextSeedBuilder<TContext>(dbConfig);
             this.databaseConfigurations.Add(dbConfig);
@@ -221,7 +222,7 @@ namespace Janus
         private string ReplaceDatabaseNameOnConnectionString(string newDbName, string connectionString, string connectionStringDatabaseKey)
         {
             Dictionary<string, string> connectionStringParts = this.GetConnectionStringParts(connectionString);
-            if (!connectionStringParts.TryGetValue(connectionStringDatabaseKey, out string key))
+            if (!connectionStringParts.TryGetValue(connectionStringDatabaseKey, out _))
             {
                 throw new KeyNotFoundException($"The connection string database key of {connectionStringDatabaseKey} does not exist in the connection string.");
             }

--- a/src/Janus.Core/Janus.csproj
+++ b/src/Janus.Core/Janus.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Janus</AssemblyName>
     <RootNamespace>Janus</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.0-beta-1.1</Version>
+    <Version>1.0.0</Version>
     <Authors>Johnathon Sullinger</Authors>
     <Company>Johnathon Sullinger</Company>
     <Description>Provides per-integration test database provisioning and database seeding for projects that utilize Entity Framework Core.</Description>

--- a/src/Janus.Core/Janus.csproj
+++ b/src/Janus.Core/Janus.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Janus</AssemblyName>
     <RootNamespace>Janus</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.0-beta-1.0</Version>
+    <Version>1.0.0-beta-1.1</Version>
     <Authors>Johnathon Sullinger</Authors>
     <Company>Johnathon Sullinger</Company>
     <Description>Provides per-integration test database provisioning and database seeding for projects that utilize Entity Framework Core.</Description>

--- a/src/Janus.Core/Seeding/ISeederCollection.cs
+++ b/src/Janus.Core/Seeding/ISeederCollection.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Janus.Seeding
+{
+    public interface ISeederCollection
+    {
+        void AddSeeder<TSeeder>() where TSeeder : IEntitySeeder;
+        Type[] GetSeederTypes();
+    }
+}

--- a/src/Janus.Core/Seeding/SeederCollection.cs
+++ b/src/Janus.Core/Seeding/SeederCollection.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Janus.Seeding
+{
+    public class SeederCollection : ISeederCollection
+    {
+        private List<Type> seeders = new List<Type>();
+
+        public void AddSeeder<TSeeder>() where TSeeder : IEntitySeeder
+        {
+            this.seeders.Add(typeof(TSeeder));
+        }
+
+        public Type[] GetSeederTypes()
+        {
+            return this.seeders.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
This adds new seed collection API support along with moving the NuGet package version to 1.0.0.

A SeederCollection can be subclassed and setup to aggregate seeders.

```c#
    public class UserTaskCollection : SeederCollection
    {
        public UserTaskCollection()
        {
            this.AddSeeder<UserEntitySeeder>();
            this.AddSeeder<TaskEntitySeeder>();
        }
    }
```

Then registered within the integration test, instead of registering the individual seeders.

```c#
    [TestMethod]
    [TestCategory("Samples")]
    public async Task GetUsers_ReturnsSeederData()
    {
        // Arrange
        this.testFactory.WithDataContext<AppDbContext>("Default")
            .WithSeedCollection<UserTaskCollection>();

        var client = testFactory.CreateClient();
        IEntitySeeder userSeeder = testFactory.GetDataContextSeedData<AppDbContext, UserEntitySeeder>();

        // Act
        HttpResponseMessage response = await client.GetAsync("api/users");
        string responseBody = await response.Content.ReadAsStringAsync();
        UserEntity[] responseData = JsonConvert.DeserializeObject<UserEntity[]>(responseBody);

        // Assert
        Assert.AreEqual(userSeeder.GetSeedData().Length, responseData.Length);
    }
```