### PR TITLE
Support for explicitly using the database in the app connection string instead of a unique database per test

### DIFF
--- a/samples/ApiSample/src/Data/AppDbContext.cs
+++ b/samples/ApiSample/src/Data/AppDbContext.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using System;
 
 namespace Janus.SampleApi.Data
 {
     public class AppDbContext : DbContext
     {
-        public AppDbContext(DbContextOptions options) : base(options) { }
+        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
 
         public DbSet<UserEntity> Users { get; set; }
 

--- a/samples/ApiSample/src/appsettings.json
+++ b/samples/ApiSample/src/appsettings.json
@@ -6,6 +6,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Default": "Data Source=SampleApi.db"
+    "Default": "Data Source=SampleDb.db"
   }
 }

--- a/samples/ApiSample/test/SampleApi.Tests.csproj
+++ b/samples/ApiSample/test/SampleApi.Tests.csproj
@@ -8,6 +8,8 @@
     <RootNamespace>AspNetCore.IntegrationTestSeeding</RootNamespace>
 
     <AssemblyName>AspNetCore.IntegrationTestSeeding.Tests</AssemblyName>
+
+    <UserSecretsId>4d21d38b-6acb-4e5a-bc97-d1f3852ddbaf</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ApiSample/test/Tests/CreateDbContextTests.cs
+++ b/samples/ApiSample/test/Tests/CreateDbContextTests.cs
@@ -22,6 +22,10 @@ namespace Janus.SampleApi
             // Replace with "Initial Catalog" for Sql Server or "database" for MySql.
             this.testFactory = new ApiIntegrationTestFactory<Startup>("Data Source")
                 .SetSolutionRelativeContentRoot("samples\\ApiSample\\src");
+
+            this.testFactory
+                .WithDataContext<AppDbContext>("Default")
+                .WithSeedData<UserEntitySeeder>();
         }
 
         [TestCleanup]
@@ -35,8 +39,7 @@ namespace Janus.SampleApi
         [TestCategory("Samples")]
         public async Task GetUsers_ReturnsOkStatusCode()
         {
-            // Arrange - Sets up and creates the database.
-            this.testFactory.WithDataContext<AppDbContext>("Default");
+            // Arrange
             var client = this.testFactory.CreateClient();
 
             // Act

--- a/samples/ApiSample/test/Tests/SeedCollectionTests.cs
+++ b/samples/ApiSample/test/Tests/SeedCollectionTests.cs
@@ -47,7 +47,6 @@ namespace Janus.SampleApi
             string responseBody = await response.Content.ReadAsStringAsync();
             UserEntity[] responseData = JsonConvert.DeserializeObject<UserEntity[]>(responseBody);
 
-
             // Assert
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.AreEqual(userSeeder.GetSeedData().Length, responseData.Length);

--- a/src/Janus.Core/ApiIntegrationTestFactory`1.cs
+++ b/src/Janus.Core/ApiIntegrationTestFactory`1.cs
@@ -109,6 +109,13 @@ namespace Janus
                     continue;
                 }
 
+                // These might be null in a suite of tests where some tests are configured with a Factory
+                // in a [TestInitialize] method and some have a Factory created within the test itself.
+                if (this.Server?.Host?.Services == null)
+                {
+                    continue;
+                }
+
                 DbContext context;
                 using (IServiceScope serviceScope = this.Server.Host.Services.CreateScope())
                 {
@@ -116,6 +123,7 @@ namespace Janus
                     context.Database.EnsureDeleted();
                 }
             }
+
             base.Dispose(disposing);
         }
 
@@ -123,6 +131,11 @@ namespace Janus
         {
             foreach (TestDatabaseConfiguration dbConfig in this.databaseConfigurations)
             {
+                if (dbConfig.UseConfigurationDatabase)
+                {
+                    continue;
+                }
+
                 this.RenameConnectionStringDatabase(builder, dbConfig);
             }
 

--- a/src/Janus.Core/DbContextSeedBuilder`1.cs
+++ b/src/Janus.Core/DbContextSeedBuilder`1.cs
@@ -19,5 +19,11 @@ namespace Janus
             base.TestConfiguration.RetainDatabase = true;
             return this;
         }
+
+        public DbContextSeedBuilder<TContext> UseConfiguredConnectionString()
+        {
+            base.TestConfiguration.UseConfigurationDatabase = true;
+            return this;
+        }
     }
 }

--- a/src/Janus.Core/TestDatabaseConfiguration.cs
+++ b/src/Janus.Core/TestDatabaseConfiguration.cs
@@ -4,6 +4,10 @@ namespace Janus
 {
     public class TestDatabaseConfiguration
     {
+        private bool useConfigurationConnectionString = false;
+        private bool? requestedRetainDatabase = null;
+        private bool retainDatabase = false;
+
         public TestDatabaseConfiguration(string configurationConnectionStringKey, Type dbContextType, string testName)
         {
             if (string.IsNullOrEmpty(configurationConnectionStringKey))
@@ -29,9 +33,44 @@ namespace Janus
         internal Type DbContextType { get; set; }
         internal string ConfigurationConnectionStringKey { get; set; }
         internal string ConnectionStringDatabaseKey { get; set; }
-        internal bool RetainDatabase { get; set; }
         internal string ExecutingTest { get; set; }
         internal Delegate DatabaseSeeder { get; set; }
         internal DbContextSeedBuilder SeedBuilder { get; set; }
+
+
+        internal bool RetainDatabase
+        {
+            get
+            {
+                return this.retainDatabase;
+            }
+            set
+            {
+                this.retainDatabase = value;
+                if (!value)
+                {
+                    // Do not allow UseConfigurationDatabase to be true if you opt to not retain databases.
+                    this.UseConfigurationDatabase = false;
+                }
+            }
+        }
+
+        internal bool UseConfigurationDatabase
+        {
+            get
+            {
+                return this.useConfigurationConnectionString;
+            }
+            set
+            {
+                this.useConfigurationConnectionString = value;
+                if (value)
+                {
+                    // Do not allow RetainDatabase to be false if you opt to use the connection string defined by
+                    // the applications TStartup configuration.
+                    this.RetainDatabase = true;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This adds a new API method on the `DbContextSeedBuilder<TContext>` class so that tests can use the database specified in the connection string configured in the app, instead of a unique database per-test.

You configure it per `WIthDataContext<TContext>` call.

```c#
var testFactory = new ApiIntegrationTestFactory<Startup>("Data Source")
    .SetSolutionRelativeContentRoot("samples\\ApiSample\\src");

testFactory
    .WithDataContext<AppDbContext>("Default")
    .UseConfiguredConnectionString();
```